### PR TITLE
test: docker build cache CI verification

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -1,14 +1,9 @@
 name: Docker Release
 
 on:
-  push:
+  pull_request:
     branches:
-      - master
-    tags-ignore: # prevents to run duplicated on releases
-      - '**'
-  release:
-    types:
-      - created
+      - refactor/docker-build-cache
 
 jobs:
   build-push:
@@ -23,19 +18,6 @@ jobs:
 
       - uses: docker/setup-buildx-action@v3
       - uses: docker/setup-qemu-action@v3
-
-      - name: Login to dockerhub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-
-      - name: Login to Github Packages
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create Docker Meta
         id: docker_meta
@@ -80,7 +62,7 @@ jobs:
           context: . # without this it will clone master branch instead of using local
           cache-from: type=gha,scope=zwave-js-ui
           cache-to: type=gha,mode=max,scope=zwave-js-ui
-          push: true
+          push: false
           tags: ${{ steps.docker_meta.outputs.tags }}
           labels: ${{ steps.docker_meta.outputs.labels }}
 
@@ -97,6 +79,6 @@ jobs:
           build-args: |
             image=zwavejs2mqtt
           cache-to: type=gha,mode=max,scope=zwavejs2mqtt
-          push: true
+          push: false
           tags: ${{ steps.docker_meta2.outputs.tags }}
           labels: ${{ steps.docker_meta2.outputs.labels }}


### PR DESCRIPTION
## Summary

- Triggers the Docker build workflow without pushing images or requiring registry credentials
- Validates the layer/GHA cache configuration from `refactor/docker-build-cache`

## Changes

- Removed Docker Hub and GHCR login steps (secrets not configured on fork)
- Changed trigger to `pull_request` targeting `refactor/docker-build-cache`
- Set `push: false` on both build steps

> This is a throwaway test branch — do not merge.